### PR TITLE
Restyle UI to match meghannewell.com aesthetic

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,38 +48,38 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --background: #f5f5eb;
+  --foreground: #380d00;
+  --card: #f5f5eb;
+  --card-foreground: #380d00;
+  --popover: #f5f5eb;
+  --popover-foreground: #380d00;
+  --primary: #3e3e3e;
+  --primary-foreground: #ffffff;
+  --secondary: #ece9e0;
+  --secondary-foreground: #380d00;
+  --muted: #ece9e0;
+  --muted-foreground: #797979;
+  --accent: #ece9e0;
+  --accent-foreground: #380d00;
+  --destructive: #f0523d;
+  --border: #e9e9e9;
+  --input: #e9e9e9;
+  --ring: #9c5454;
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: #f0f0e6;
+  --sidebar-foreground: #380d00;
+  --sidebar-primary: #3e3e3e;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ece9e0;
+  --sidebar-accent-foreground: #380d00;
+  --sidebar-border: #e9e9e9;
+  --sidebar-ring: #9c5454;
 }
 
 .dark {

--- a/src/components/calculator/input-group.tsx
+++ b/src/components/calculator/input-group.tsx
@@ -29,7 +29,7 @@ export function InputGroup({
       <Label className="text-xs text-muted-foreground">{label}</Label>
       <div className="relative flex items-center">
         {prefix && (
-          <span className="absolute left-2.5 text-sm text-muted-foreground pointer-events-none">
+          <span className="absolute left-0 text-sm text-muted-foreground pointer-events-none">
             {prefix}
           </span>
         )}
@@ -40,10 +40,10 @@ export function InputGroup({
           step={step}
           min={min}
           max={max}
-          className={prefix ? "pl-6" : suffix ? "pr-6" : ""}
+          className={prefix ? "pl-4" : suffix ? "pr-4" : ""}
         />
         {suffix && (
-          <span className="absolute right-2.5 text-sm text-muted-foreground pointer-events-none">
+          <span className="absolute right-0 text-sm text-muted-foreground pointer-events-none">
             {suffix}
           </span>
         )}

--- a/src/components/calculator/monthly-cost-chart.tsx
+++ b/src/components/calculator/monthly-cost-chart.tsx
@@ -12,13 +12,12 @@ import {
 import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
 
 const COLORS = [
-  "oklch(0.65 0.19 145)",
-  "oklch(0.62 0.21 260)",
-  "oklch(0.55 0.24 263)",
-  "oklch(0.65 0.20 30)",
-  "oklch(0.58 0.22 330)",
-  "oklch(0.50 0.20 290)",
-  "oklch(0.60 0.18 200)",
+  "#f5ed68",
+  "#f6d164",
+  "#f7b460",
+  "#f7985b",
+  "#f87b57",
+  "#f95f53",
 ];
 
 function fmtK(n: number): string {

--- a/src/components/calculator/scenario-comparison-chart.tsx
+++ b/src/components/calculator/scenario-comparison-chart.tsx
@@ -10,13 +10,12 @@ import {
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Cell } from "recharts";
 
 const COLORS = [
-  "oklch(0.65 0.19 145)",
-  "oklch(0.62 0.21 260)",
-  "oklch(0.55 0.24 263)",
-  "oklch(0.65 0.20 30)",
-  "oklch(0.58 0.22 330)",
-  "oklch(0.50 0.20 290)",
-  "oklch(0.60 0.18 200)",
+  "#f5ed68",
+  "#f6d164",
+  "#f7b460",
+  "#f7985b",
+  "#f87b57",
+  "#f95f53",
 ];
 
 function fmtK(n: number): string {

--- a/src/components/calculator/wealth-chart.tsx
+++ b/src/components/calculator/wealth-chart.tsx
@@ -12,13 +12,12 @@ import {
 import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
 
 const COLORS = [
-  "oklch(0.65 0.19 145)",   // green  — rent
-  "oklch(0.62 0.21 260)",   // blue
-  "oklch(0.55 0.24 263)",   // indigo
-  "oklch(0.65 0.20 30)",    // orange
-  "oklch(0.58 0.22 330)",   // pink
-  "oklch(0.50 0.20 290)",   // purple
-  "oklch(0.60 0.18 200)",   // teal
+  "#f5ed68",
+  "#f6d164",
+  "#f7b460",
+  "#f7985b",
+  "#f87b57",
+  "#f95f53",
 ];
 
 function fmtK(n: number): string {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,11 +6,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-none border border-transparent bg-clip-padding text-[11px] font-medium tracking-[0.5px] uppercase whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-black",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-[44px] gap-1.5 px-7 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-none bg-card py-4 text-sm text-card-foreground has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0",
         className
       )}
       {...props}
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        "text-base leading-snug font-medium tracking-tight text-[#9c5454] group-data-[size=sm]/card:text-sm",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-none border-0 border-b border-input bg-transparent px-0 py-1 text-sm transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/50 focus-visible:border-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive",
         className
       )}
       {...props}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
     <label
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-[11px] leading-none font-normal tracking-[0.08em] uppercase select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -41,7 +41,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex w-fit items-center justify-between gap-1.5 rounded-none border-0 border-b border-input bg-transparent py-2 pr-2 pl-0 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-foreground disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Warm off-white background (#f5f5eb), dark brown text (#380d00), dusty rose accents (#9c5454)
- Bottom-border-only inputs and selects, uppercase 11px labels with letter-spacing
- Flat dark buttons (#3e3e3e), no rounded corners, hover goes black
- Cards: removed ring border and rounded corners, dusty rose titles
- Charts: yellow-to-coral diverging palette (#F5ED68 → #F95F53) via d3 interpolateRgb

## Test plan
- [ ] Verify form styling matches contact page aesthetic
- [ ] Verify chart colors display the yellow-to-coral gradient
- [ ] Check responsive layout still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)