### PR TITLE
Add current savings/wealth to calculator (#9)

### DIFF
--- a/src/components/calculator/input-form.tsx
+++ b/src/components/calculator/input-form.tsx
@@ -66,6 +66,25 @@ export function InputForm({ inputs, onChange }: InputFormProps) {
         </div>
       </section>
 
+      {/* Current Savings */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold">Current Savings</h3>
+        <InputGroup
+          label="Non-Retirement Investments"
+          value={inputs.nonRetirementSavings}
+          onChange={(v) => update("nonRetirementSavings", v)}
+          prefix="$"
+          step={10000}
+        />
+        <InputGroup
+          label="Retirement Accounts (401k/IRA)"
+          value={inputs.retirementSavings}
+          onChange={(v) => update("retirementSavings", v)}
+          prefix="$"
+          step={10000}
+        />
+      </section>
+
       {/* Home Prices */}
       <section className="space-y-3">
         <h3 className="text-sm font-semibold">Home Prices</h3>

--- a/src/lib/calculator/defaults.ts
+++ b/src/lib/calculator/defaults.ts
@@ -16,4 +16,6 @@ export const DEFAULT_INPUTS: CalculatorInputs = {
   buyerClosingPercent: 2,
   sellerClosingPercent: 5,
   filingStatus: "single",
+  nonRetirementSavings: 0,
+  retirementSavings: 0,
 };

--- a/src/lib/calculator/engine.ts
+++ b/src/lib/calculator/engine.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types";
 import { monthlyPayment, remainingBalance, interestPaidInYear } from "./mortgage";
 import { calcPropertyTax, calcTotalTaxBenefit } from "./taxes";
+import { DEFAULT_INPUTS } from "./defaults";
 
 function buildScenarios(inputs: CalculatorInputs): BuyScenario[] {
   const terms: (15 | 30)[] = [15, 30];
@@ -34,34 +35,49 @@ function buildScenarios(inputs: CalculatorInputs): BuyScenario[] {
 }
 
 export function computeResults(inputs: CalculatorInputs): CalculatorResults {
-  const scenarios = buildScenarios(inputs);
+  // Backward compat: old saved calculations missing new fields get defaults
+  const safeInputs = { ...DEFAULT_INPUTS, ...inputs };
+  const scenarios = buildScenarios(safeInputs);
   const yearSnapshots: YearSnapshot[] = [];
 
   // Track cumulative state
   let rentCumulativeCost = 0;
-  // Renter invests the down payment + closing costs they didn't spend
+  // Renter keeps all savings plus what they didn't spend on buying
   const rentInvestmentBases = scenarios.map(
-    (s) => s.downPayment + s.price * (inputs.buyerClosingPercent / 100)
+    (s) => safeInputs.nonRetirementSavings + s.downPayment + s.price * (safeInputs.buyerClosingPercent / 100)
   );
   const rentInvestmentBalances = [...rentInvestmentBases];
+  // Buyer's remaining non-retirement portfolio after down payment + closing costs
+  const buyInvestmentBalances = scenarios.map(
+    (s) => Math.max(0, safeInputs.nonRetirementSavings - s.downPayment - s.price * (safeInputs.buyerClosingPercent / 100))
+  );
   const buyCumulativeCosts = scenarios.map(() => 0);
 
   for (let year = 1; year <= 30; year++) {
     // --- Rent ---
-    const monthlyRent = inputs.monthlyRent * Math.pow(1 + inputs.rentEscalationRate / 100, year - 1);
+    const monthlyRent = safeInputs.monthlyRent * Math.pow(1 + safeInputs.rentEscalationRate / 100, year - 1);
     const rentAnnualCost = monthlyRent * 12;
     rentCumulativeCost += rentAnnualCost;
 
-    // Grow each renter investment balance and add monthly savings
+    // Grow each renter investment balance
     for (let i = 0; i < scenarios.length; i++) {
-      rentInvestmentBalances[i] *= 1 + inputs.investmentReturnRate / 100;
+      rentInvestmentBalances[i] *= 1 + safeInputs.investmentReturnRate / 100;
     }
+
+    // Grow buyer investment balances
+    for (let i = 0; i < scenarios.length; i++) {
+      buyInvestmentBalances[i] *= 1 + safeInputs.investmentReturnRate / 100;
+    }
+
+    // Retirement grows identically for both sides
+    const retirementBalance = safeInputs.retirementSavings * Math.pow(1 + safeInputs.investmentReturnRate / 100, year);
 
     const rent: RentYearSnapshot = {
       monthlyRent,
       annualCost: rentAnnualCost,
       cumulativeCost: rentCumulativeCost,
       investmentBalance: rentInvestmentBalances[0], // Use first scenario's for display
+      retirementBalance,
       totalWealth: rentInvestmentBalances[0],
     };
 
@@ -70,21 +86,21 @@ export function computeResults(inputs: CalculatorInputs): CalculatorResults {
       const { price, term, loanAmount, monthlyPI } = scenario;
 
       // Property tax with Prop 13
-      const annualPropertyTax = calcPropertyTax(price, inputs.propertyTaxRate, year);
+      const annualPropertyTax = calcPropertyTax(price, safeInputs.propertyTaxRate, year);
       const monthlyPropertyTax = annualPropertyTax / 12;
 
       // Monthly costs
-      const monthlyInsurance = inputs.annualInsurance / 12;
-      const monthlyMaintenance = (price * (inputs.maintenancePercent / 100)) / 12;
-      const monthlyHousingCost = monthlyPI + monthlyPropertyTax + monthlyInsurance + inputs.monthlyHoa + monthlyMaintenance;
+      const monthlyInsurance = safeInputs.annualInsurance / 12;
+      const monthlyMaintenance = (price * (safeInputs.maintenancePercent / 100)) / 12;
+      const monthlyHousingCost = monthlyPI + monthlyPropertyTax + monthlyInsurance + safeInputs.monthlyHoa + monthlyMaintenance;
 
       // Tax benefit
-      const yearInterest = year <= term ? interestPaidInYear(loanAmount, inputs.mortgageRate, term, year) : 0;
+      const yearInterest = year <= term ? interestPaidInYear(loanAmount, safeInputs.mortgageRate, term, year) : 0;
       const monthlyTaxBenefit = calcTotalTaxBenefit(
         yearInterest,
         annualPropertyTax,
-        inputs.annualIncome,
-        inputs.filingStatus
+        safeInputs.annualIncome,
+        safeInputs.filingStatus
       );
 
       const netMonthlyCost = monthlyHousingCost - monthlyTaxBenefit;
@@ -92,14 +108,15 @@ export function computeResults(inputs: CalculatorInputs): CalculatorResults {
       buyCumulativeCosts[i] += annualCost;
 
       // Home value and equity
-      const homeValue = price * Math.pow(1 + inputs.appreciationRate / 100, year);
+      const homeValue = price * Math.pow(1 + safeInputs.appreciationRate / 100, year);
       const monthsPaid = Math.min(year * 12, term * 12);
       const balance = year <= term
-        ? remainingBalance(loanAmount, inputs.mortgageRate, term, monthsPaid)
+        ? remainingBalance(loanAmount, safeInputs.mortgageRate, term, monthsPaid)
         : 0;
       const equity = homeValue - Math.max(0, balance);
-      const sellerClosing = homeValue * (inputs.sellerClosingPercent / 100);
+      const sellerClosing = homeValue * (safeInputs.sellerClosingPercent / 100);
       const netSaleProceeds = equity - sellerClosing;
+      const nonRetirementPortfolio = buyInvestmentBalances[i];
 
       return {
         monthlyHousingCost,
@@ -111,7 +128,9 @@ export function computeResults(inputs: CalculatorInputs): CalculatorResults {
         remainingBalance: Math.max(0, balance),
         equity,
         netSaleProceeds,
-        totalWealth: netSaleProceeds,
+        nonRetirementPortfolio,
+        retirementBalance,
+        totalWealth: netSaleProceeds + nonRetirementPortfolio,
       };
     });
 
@@ -124,7 +143,7 @@ export function computeResults(inputs: CalculatorInputs): CalculatorResults {
     let breakevenYear: number | null = null;
     let investBal = rentInvestmentBases[i];
     for (let y = 1; y <= 30; y++) {
-      investBal *= 1 + inputs.investmentReturnRate / 100;
+      investBal *= 1 + safeInputs.investmentReturnRate / 100;
       const buyWealth = yearSnapshots[y - 1].buy[i].totalWealth;
       if (breakevenYear === null && buyWealth > investBal) {
         breakevenYear = y;
@@ -145,15 +164,15 @@ export function computeResults(inputs: CalculatorInputs): CalculatorResults {
   let rentInvBal30 = rentInvestmentBases[0];
   for (let y = 1; y <= 30; y++) {
     if (y <= 10) {
-      rentInvBal10 = rentInvestmentBases[0] * Math.pow(1 + inputs.investmentReturnRate / 100, y);
+      rentInvBal10 = rentInvestmentBases[0] * Math.pow(1 + safeInputs.investmentReturnRate / 100, y);
     }
-    rentInvBal30 = rentInvestmentBases[0] * Math.pow(1 + inputs.investmentReturnRate / 100, y);
+    rentInvBal30 = rentInvestmentBases[0] * Math.pow(1 + safeInputs.investmentReturnRate / 100, y);
   }
 
   return {
     scenarios,
     yearSnapshots,
-    rentYear1Monthly: inputs.monthlyRent,
+    rentYear1Monthly: safeInputs.monthlyRent,
     rentWealth10yr: rentInvBal10,
     rentWealth30yr: rentInvBal30,
     summaries,

--- a/src/lib/calculator/types.ts
+++ b/src/lib/calculator/types.ts
@@ -16,6 +16,8 @@ export interface CalculatorInputs {
   buyerClosingPercent: number;
   sellerClosingPercent: number;
   filingStatus: FilingStatus;
+  nonRetirementSavings: number;
+  retirementSavings: number;
 }
 
 export interface BuyScenario {
@@ -32,6 +34,7 @@ export interface RentYearSnapshot {
   annualCost: number;
   cumulativeCost: number;
   investmentBalance: number;
+  retirementBalance: number;
   totalWealth: number;
 }
 
@@ -45,6 +48,8 @@ export interface BuyYearSnapshot {
   remainingBalance: number;
   equity: number;
   netSaleProceeds: number;
+  nonRetirementPortfolio: number;
+  retirementBalance: number;
   totalWealth: number;
 }
 


### PR DESCRIPTION
## Summary

- Adds **non-retirement investments** and **retirement accounts** inputs to the calculator, enabling more realistic 30-year wealth comparisons
- Renter's investment base now includes their full savings (not just the opportunity cost of down payment + closing costs)
- Buyer tracks remaining non-retirement portfolio after spending on down payment + closing costs, grown at the same investment return rate
- Buyer `totalWealth` = `netSaleProceeds + nonRetirementPortfolio` (previously just `netSaleProceeds`)
- Fully backward compatible — old saved calculations missing the new fields default to 0, producing identical results

## Files changed

| File | Change |
|------|--------|
| `src/lib/calculator/types.ts` | Add `nonRetirementSavings`, `retirementSavings` to inputs; `retirementBalance` to rent snapshots; `nonRetirementPortfolio`, `retirementBalance` to buy snapshots |
| `src/lib/calculator/defaults.ts` | Default both new fields to `0` |
| `src/lib/calculator/engine.ts` | Update rent investment base, track buyer portfolio, compute retirement balance, use `safeInputs` for backward compat |
| `src/components/calculator/input-form.tsx` | Add "Current Savings" section with two inputs |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] With savings = 0, results match current behavior exactly
- [ ] With nonRetirementSavings = 500000, renter totalWealth includes savings grown at return rate; buyer totalWealth = equity + remaining portfolio
- [ ] When savings < downPayment + closing costs, buyer portfolio floors at 0
- [ ] Breakeven year shifts later when savings are added
- [ ] Old saved calculations load correctly with missing fields defaulting to 0

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)