### PR TITLE
Move action buttons into sidebar with layout fixes

### DIFF
--- a/src/components/calculator/calculator-page.tsx
+++ b/src/components/calculator/calculator-page.tsx
@@ -32,28 +32,29 @@ export function CalculatorPage({ initialInputs, initialId, initialName }: Calcul
 
   return (
     <div className="p-4 lg:p-6 space-y-6">
-      {/* Full-width title row */}
-      <div className="flex items-center justify-between gap-4">
-        <ScenarioSelector savedId={savedId} savedName={savedName} />
-        <div className="flex items-center gap-2">
-          <SaveDialog
-            currentName={savedName}
-            saving={saving}
-            dirty={dirty}
-            savedId={savedId}
-            onSave={save}
-          />
-          <Button size="sm" variant="outline" onClick={() => router.push("/dashboard")}>
-            New
-          </Button>
-          {savedId && <ShareButton calculationId={savedId} />}
-        </div>
-      </div>
-
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Sidebar — input form */}
         <aside className="w-full lg:w-[380px] shrink-0">
           <div className="sticky top-20 space-y-4 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2">
+            <ScenarioSelector
+              savedId={savedId}
+              savedName={savedName}
+              actions={
+                <div className="flex items-center gap-2 shrink-0">
+                  <SaveDialog
+                    currentName={savedName}
+                    saving={saving}
+                    dirty={dirty}
+                    savedId={savedId}
+                    onSave={save}
+                  />
+                  <Button size="sm" variant="outline" onClick={() => router.push("/dashboard")}>
+                    New
+                  </Button>
+                  {savedId && <ShareButton calculationId={savedId} />}
+                </div>
+              }
+            />
             <InputForm inputs={inputs} onChange={setInputs} />
           </div>
         </aside>

--- a/src/components/calculator/scenario-selector.tsx
+++ b/src/components/calculator/scenario-selector.tsx
@@ -15,9 +15,10 @@ interface Calculation {
 interface ScenarioSelectorProps {
   savedId: string | null;
   savedName: string;
+  actions?: React.ReactNode;
 }
 
-export function ScenarioSelector({ savedId, savedName }: ScenarioSelectorProps) {
+export function ScenarioSelector({ savedId, savedName, actions }: ScenarioSelectorProps) {
   const { data: session } = useSession();
   const [calculations, setCalculations] = useState<Calculation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -62,20 +63,28 @@ export function ScenarioSelector({ savedId, savedName }: ScenarioSelectorProps) 
   const hasScenarios = session?.user && !loading && calculations.length > 0;
 
   if (!hasScenarios) {
-    return <h1 className="text-2xl font-bold">{displayName}</h1>;
+    return (
+      <div className="flex items-start justify-between gap-2">
+        <h1 className="text-2xl font-bold text-left">{displayName}</h1>
+        {actions}
+      </div>
+    );
   }
 
   return (
     <div>
-      <button
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 text-2xl font-bold cursor-pointer bg-transparent border-none p-0"
-      >
-        <ChevronRight
-          className={`h-5 w-5 transition-transform ${open ? "rotate-90" : ""}`}
-        />
-        {displayName}
-      </button>
+      <div className="flex items-start justify-between gap-2">
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex items-start gap-2 text-2xl font-bold text-left cursor-pointer bg-transparent border-none p-0"
+        >
+          <ChevronRight
+            className={`h-5 w-5 mt-1.5 shrink-0 transition-transform ${open ? "rotate-90" : ""}`}
+          />
+          {displayName}
+        </button>
+        {actions}
+      </div>
 
       {open && (
         <div className="mt-2 space-y-1">

--- a/src/components/calculator/share-button.tsx
+++ b/src/components/calculator/share-button.tsx
@@ -36,17 +36,7 @@ export function ShareButton({ calculationId }: ShareButtonProps) {
       onClick={handleShare}
       disabled={sharing}
     >
-      {copied ? (
-        <>
-          <Check className="h-3.5 w-3.5 mr-1" />
-          Copied!
-        </>
-      ) : (
-        <>
-          <Link2 className="h-3.5 w-3.5 mr-1" />
-          {sharing ? "Sharing..." : "Share Scenario"}
-        </>
-      )}
+      {copied ? "Copied!" : sharing ? "Sharing..." : "Share"}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Move Save/New/Share buttons from full-width title row into the left sidebar, next to the scenario selector
- Buttons stay top-aligned while the scenario dropdown list spans full sidebar width
- Rename "Share Scenario" to "Share" and remove icon from share button
- Left-align scenario title text when long names wrap to multiple lines

## Test plan
- [x] Buttons appear next to scenario title in sidebar
- [x] Long scenario names wrap left-aligned, buttons stay at top
- [x] Dropdown list spans full sidebar width below title row
- [x] Share button shows "Share" with no icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)